### PR TITLE
Add oplog-dump cmd

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,21 @@
+image: go1.2
+script:
+  - env
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - sudo echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-get update
+  - sudo apt-get install mongodb-org
+  - mongo --eval 'rs.initiate()'
+  - make test
+services:
+  - schimmy/mongodb-tailtest:2.6
+notify:
+  email:
+    recipients:
+      - drone@clever.com
+  hipchat:
+    room: Clever-Dev-CI
+    token: {{hipchatToken}}
+    on_started: true
+    on_success: true
+    on_failure: true

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+bin/
+*.swo
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: build test
+
+deps:
+	go get -t ./...
+
+build: deps
+	go build -o bin/oplog-dump github.com/Clever/oplog-dump/cmd/oplog-dump
+
+test: deps
+	go test github.com/Clever/oplog-dump/cmd/oplog-dump

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 oplog-dump
 ==========
+A binary that dumps the oplog from MongoDB.
+
+This has some advantages over a direct mongodump command:
+- Its interface is designed specifically for creating oplog dumps for a certain point in time.
+- It can be used in conjunction with www.github.com/Clever/oplog-replay to run Mongo operations on multiple databases.
+
+
+Usage
+-----
+Build Oplog Dump and put it in your GOPATH with:
+
+`go get github.com/Clever/oplog-dump/cmd`
+
+Run it as follows:
+`oplog-dump --dir /tmp/out`
+
+Params:
+  -dir="": The directory to dump the data to
+  -mongoUrl="localhost": The URL to dump from
+  -unixTime=0: Grab all oplog entries greater than or equal to this timestamp

--- a/cmd/oplog-dump/oplogdump.go
+++ b/cmd/oplog-dump/oplogdump.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func main() {
+	unixTime := flag.Int("time", 0, "Only get the entries greater than or equal to this unix timestamp")
+	mongoUrl := flag.String("host", "localhost", "The mongo url")
+	dumpDir := flag.String("dir", "", "The directory where the data is dumped")
+	flag.Parse()
+
+	if len(*dumpDir) == 0 {
+		log.Printf("Error: 'dir' not set")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	if err := runDump(*dumpDir, *mongoUrl, *unixTime); err != nil {
+		// Try to return the same exit code as mongodump. This doesn't work on all platforms,
+		// so if we can't figure out the exit code then we just use the exit code 2.
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(status.ExitStatus())
+			}
+		}
+		os.Exit(2)
+	}
+}
+
+// runDump runs the mongodump command. It's factored out so that it can be unit tested easily.
+func runDump(dumpDir, host string, unixTime int) error {
+	cmd := exec.Command("mongodump",
+		"--db", "local",
+		"--collection", "oplog.rs",
+		"--out", dumpDir,
+		"--host", host,
+		"--query", fmt.Sprintf("{ts : { $gte : Timestamp(%d, 0)}}", unixTime))
+	// Forward stderr for logging / debugging. Note that we forward stdout to stderr so that it doesn't
+	// polluate the command's return value (ie stdout)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/oplog-dump/oplogdump_test.go
+++ b/cmd/oplog-dump/oplogdump_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"labix.org/v2/mgo"
+
+	"github.com/stretchr/testify/assert"
+
+	bsonScanner "github.com/Clever/oplog-replay/bson"
+)
+
+// simpleDocStruct is for inserting simple Mongo documents
+type simpleDocStruct struct {
+	key string
+}
+
+func TestComposingWithOplogReplay(t *testing.T) {
+	// This test assumes that we're connecting to Mongo replica set. Otherwise, the oplog won't
+	// be generated.
+
+	unixTime := int(time.Now().Unix())
+
+	time.Sleep(time.Duration(2) * time.Second)
+
+	session, err := mgo.Dial("localhost")
+	assert.Nil(t, err)
+	db := session.DB("myTestDb")
+	c := db.C("myCollection")
+	assert.Nil(t, c.Insert(&simpleDocStruct{key: "key"}))
+
+	time.Sleep(time.Duration(2) * time.Second)
+
+	assert.Nil(t, c.Insert(&simpleDocStruct{key: "key2"}))
+	// Dump at the time we started operations. Should get both operations
+	dumpAtTime(t, unixTime, 2)
+	// Three seconds later we should get only one.
+	dumpAtTime(t, unixTime+3, 1)
+}
+
+func dumpAtTime(t *testing.T, unixTime, expectedResults int) {
+	tempDir, err := ioutil.TempDir("/tmp", "oplogDumpTest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+	assert.Nil(t, runDump(tempDir, "localhost", unixTime))
+
+	file, err := os.Open(tempDir + "/local/oplog.rs.bson")
+	assert.Nil(t, err)
+	scanner := bsonScanner.New(file)
+	count := 0
+	for scanner.Scan() {
+		count = count + 1
+	}
+	assert.Equal(t, expectedResults, count)
+}


### PR DESCRIPTION
This is a simple command to dump all the oplog data after a certain
timestamp.

I haven't written any tests because it's not easy to test the things
related to the oplog, but if anyone has suggestions I would love to hear
them.
