### PR TITLE
Use pathio package to write dump to arbitrary paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Run it as follows:
 `oplog-dump --dir /tmp/out`
 
 Params:
-  -dir="": The directory to dump the data to
+  -path="/dev/stdout": The path to write the dump to
   -mongoUrl="localhost": The URL to dump from
   -unixTime=0: Grab all oplog entries greater than or equal to this timestamp

--- a/cmd/oplog-dump/oplogdump_test.go
+++ b/cmd/oplog-dump/oplogdump_test.go
@@ -56,3 +56,26 @@ func dumpAtTime(t *testing.T, unixTime, expectedResults int) {
 	}
 	assert.Equal(t, expectedResults, count)
 }
+
+func TestCopyBsonFile(t *testing.T) {
+	tempDir, err := ioutil.TempDir("/tmp", "oplogDumpTest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a directory structure that mirrors the oplog one the code expects
+	err = os.Mkdir(tempDir+"/local", 0744)
+	assert.Nil(t, err)
+	file, err := os.Create(tempDir + "/local/oplog.rs.bson")
+	assert.Nil(t, err)
+	assert.Nil(t, ioutil.WriteFile(file.Name(), []byte("test-bson-file"), 0644))
+
+	// Create a file to copy to
+	toFile, err := ioutil.TempFile(tempDir, "bsonCopyTest")
+	assert.Nil(t, err)
+	assert.Nil(t, copyBsonFile(tempDir, toFile.Name()))
+
+	// Check that the data matches
+	fileData, err := ioutil.ReadFile(toFile.Name())
+	assert.Nil(t, err)
+	assert.Equal(t, "test-bson-file", string(fileData))
+}


### PR DESCRIPTION
This copies the bson file from the dump location to the location
specified by the caller
