### PR TITLE
Dockerize oplog-dump as worker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,3 +19,15 @@ notify:
     on_started: true
     on_success: true
     on_failure: true
+publish:
+  docker:
+    docker_port: 4243
+    docker_server: {{docker_server}}
+    docker_version: 1.2
+    email: {{docker_email}}
+    image_name: clever/oplog-dump
+    password: {{docker_password}}
+    push_latest: true
+    registry_login: true
+    username: {{docker_username}}
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# oplog-dump worker
+FROM ubuntu:14.04
+RUN apt-get update
+RUN apt-get install -y wget build-essential
+
+# Golang
+RUN apt-get install -y git golang bzr mercurial bash
+RUN GOPATH=/etc/go go get launchpad.net/godeb
+RUN apt-get remove -y golang golang-go golang-doc golang-src
+RUN /etc/go/bin/godeb install 1.2.1
+
+# Oplog dump
+RUN mkdir -p /etc/go/src /github.com/Clever/oplog-dump
+ADD . /etc/go/src/github.com/Clever/oplog-dump
+RUN GOPATH=/etc/go go get github.com/Clever/oplog-dump/...
+RUN GOPATH=/etc/go go build -o /usr/local/bin/oplogdump github.com/Clever/oplog-dump/cmd/oplog-dump
+
+# Taskwrapper
+RUN mkdir -p /etc/go/src /taskwrapper
+RUN GOPATH=/etc/go go get github.com/Clever/baseworker-go/cmd/taskwrapper
+RUN GOPATH=/etc/go go build -o /usr/local/bin/taskwrapper github.com/Clever/baseworker-go/cmd/taskwrapper
+
+CMD ["/etc/go/src/github.com/Clever/oplog-dump/run_as_worker.sh"]

--- a/run_as_worker.sh
+++ b/run_as_worker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+taskwrapper --name oplog-dump --cmd /usr/local/bin/oplogdump --gearman-host $GEARMAN_HOST --gearman-port $GEARMAN_PORT


### PR DESCRIPTION
This change adds a dockerfile to run oplog-dump as a worker. It does
this by using the baseworker-go/taskwrapper code. This listens to
Gearman for requests to process the job.

This change also publishes the docker image to docker hub.
