### PR TITLE
Fix race condition in test

### DIFF
--- a/cmd/oplog-dump/oplogdump_test.go
+++ b/cmd/oplog-dump/oplogdump_test.go
@@ -24,7 +24,7 @@ func TestComposingWithOplogReplay(t *testing.T) {
 
 	unixTime := int(time.Now().Unix())
 
-	time.Sleep(time.Duration(2) * time.Second)
+	time.Sleep(time.Duration(1) * time.Second)
 
 	session, err := mgo.Dial("localhost")
 	assert.Nil(t, err)
@@ -32,7 +32,7 @@ func TestComposingWithOplogReplay(t *testing.T) {
 	c := db.C("myCollection")
 	assert.Nil(t, c.Insert(&simpleDocStruct{key: "key"}))
 
-	time.Sleep(time.Duration(2) * time.Second)
+	time.Sleep(time.Duration(3) * time.Second)
 
 	assert.Nil(t, c.Insert(&simpleDocStruct{key: "key2"}))
 	// Dump at the time we started operations. Should get both operations


### PR DESCRIPTION
Before this change we would do the following.
1. Get the time
2. Sleep two seconds
3. Insert into the database
4. Do other un-related stuff which included inserting one element into
the database
5. Check that if we looked for oplog entries 3 seconds after the time we
got in step1 we would only find the db entry from step4.

This doesn't always work because sometimes rounding meant that the entry we
inserted into the database in step3 was marked as three seconds after
the start time from step1. This meant we would randomly fail this test.

To solve this we now just sleep one second in step2 so that there's no
reasonable way that we could insert the db entry at the wrong time.
