### PR TITLE
Update dockerfile to new format

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,5 +34,6 @@ script:
 - sudo apt-get install mongodb-org
 - mongo --eval 'rs.initiate()'
 - make test
+- make build
 services:
 - schimmy/mongodb-tailtest:2.6

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ publish:
     - $(git rev-parse --short HEAD)
     username: $$docker_username
     when:
-      branch: master
+      branch: new-dockerfile-format
 script:
 - env
 - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM google/debian:wheezy
+FROM debian:jessie
 
 RUN apt-get -y update && apt-get -y install curl && curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v0.4.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
 
 # Install Mongo
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10		
-RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list		
+RUN echo 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 RUN apt-get -y update && apt-get install -y mongodb-org
 
 COPY bin/oplog-dump /usr/bin/oplog-dump

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,12 @@
-# oplog-dump worker
-FROM ubuntu:14.04
+FROM google/debian:wheezy
 
-RUN apt-get -y update && apt-get install -y wget build-essential
-RUN apt-get -y update && apt-get install -y -q curl
+RUN apt-get -y update && apt-get -y install curl && curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v0.4.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
 
-# Golang
-RUN apt-get -y update && apt-get install -y git golang bzr mercurial bash
-RUN GOPATH=/etc/go go get launchpad.net/godeb
-RUN apt-get remove -y golang golang-go golang-doc golang-src
-RUN /etc/go/bin/godeb install 1.5.1
-
-# Mongo
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+# Install Mongo
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10		
+RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list		
 RUN apt-get -y update && apt-get install -y mongodb-org
 
-# Oplog dump
-RUN mkdir -p /etc/go/src /github.com/Clever/oplog-dump
-ADD . /etc/go/src/github.com/Clever/oplog-dump
-RUN GOPATH=/etc/go go get github.com/Clever/oplog-dump/...
-RUN GOPATH=/etc/go go build -o /usr/local/bin/oplogdump github.com/Clever/oplog-dump/cmd/oplog-dump
+COPY bin/oplog-dump /usr/bin/oplog-dump
 
-# Gearcmd
-RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v0.4.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
-
-CMD ["gearcmd", "--name", "oplog-dump", "--cmd", "/usr/local/bin/oplogdump", "--cmdtimeout", "1h"]
+CMD ["gearcmd", "--name", "oplog-dump", "--cmd", "/usr/bin/oplog-dump", "--cmdtimeout", "1h"]


### PR DESCRIPTION
We were having issues with the old one so let's just update it to the
new format.

Failing Build:
https://ci.ops.clever.com/github.com/Clever/oplog-dump/master/4b82f03b46c4820daadbf17a8e9225faed548381

I built the new docker image and it appeared to work