### PR TITLE
Revert "Lowered oplog-dump's cpu allocation to 0"

### DIFF
--- a/launch/oplog-dump.yml
+++ b/launch/oplog-dump.yml
@@ -8,5 +8,5 @@ dependencies:
 - gearmand
 team: eng-apps
 resources:
-  cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
+  cpu: 0.1
   max_mem: 0.05


### PR DESCRIPTION
Reverts Clever/oplog-dump#44

This caused 100% of oplog-dump jobs to fail, so reverting it