### PR TITLE
Update Gearcmd to v0.10.0 -- defaults pass-sigterm to true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:14.04
 # install gearcmd
 RUN apt-get -y update && \
     apt-get install -y -q curl && \
-    curl -L https://github.com/Clever/gearcmd/releases/download/0.8.7/gearcmd-v0.8.7-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
+    curl -L https://github.com/Clever/gearcmd/releases/download/0.10.0/gearcmd-v0.10.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
 
 # Mongo tooling
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \


### PR DESCRIPTION

Context: https://github.com/Clever/gearcmd/pull/67

We make this the default in order to match signal handling behavior in
sfncli (https://github.com/Clever/sfncli). We want to know ahead of time
if any application isn't handling sigterm correctly before moving to workflows.

Note: If this breaks application behavior, please

(0) set `pass-sigterm=false` in Dockerfile and redeploy
(1) add a note here
(2) let @xavi- or someone on eng-infra know

Thanks!